### PR TITLE
Adding Grayscale Design color tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@
 - 🎨🌍🔧 [Tailwind Gradient Designer](https://tailwind-gradient-designer.csspost.com/) - Generate a gradient for Tailwind 1.7+.
 - 🎨🌍🔧 [Tailwind Color Explorer](https://stefanbuck.com/tailwind-color-theme-explorer) - Color explorer for Tailwind CSS.
 - 🎨🌍🔧 [TailwindInk](https://tailwind.ink/) - AI palette generator, trained with the Tailwind CSS palette.
+- 🎨🌍🔧 [Grayscale Design](https://grayscale.design/) - A Luminance-based color palette generator.
 - 🌍🔧 [GPT-3 Tailwind CSS code generator](http://gpt-tailwind.com/) - OpenAI GPT-3 powered Tailwind CSS code generator.
 - 🌍🔧 [Stitches](https://stitches.hyperyolo.com/) - Template generator with Tailwind (online).
 - 🌍 [Typography Playground](https://tailwind-typography-playground.vercel.app/) - Tool for trying different Google Fonts combinations with the Tailwind CSS Typography Plugin.


### PR DESCRIPTION
| Kevin Kirchner                 | https://github.com/kevnk                 |
| -------------------- | -------------------- |
| grayscale design | https://grayscale.design |

Create a custom color palette that maintains the same luminance (color value) from color to color. For example, changing from `blue-500` to `yellow-500` will have the same luminance (appearance of light or darkness). In other words, if you were to grayscale all the color palettes, they would all appear to be the same. 

Here's a video explaining how it works: https://www.loom.com/share/3efeb1820857480d8fd2ce74b712d223

---

- [X] My item is in the right category
- [X] My item is logically grouped below similar items
- [X] My item's name and description respects the conventions of the list
- [X] My item is awesome
- [X] I have read and followed the [contribution guidelines](.github/CONTRIBUTING.md)
